### PR TITLE
chore: change cupertino to material

### DIFF
--- a/lib/sentry/SentryService.dart
+++ b/lib/sentry/SentryService.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:melton_app/util/secrets.dart';
 import 'package:sentry/sentry.dart';
 


### PR DESCRIPTION
The `@required` is being used from cupertino instead of material. 
Should not cause any issue, but changing so we can have standard usage in the codebase.